### PR TITLE
Update version of package webpack and webpack-cli.

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,8 +111,8 @@
     "uglifyjs-webpack-plugin": "^1.2.5",
     "wav-encoder": "1.3.0",
     "web-audio-test-api": "^0.5.2",
-    "webpack": "^4.6.0",
-    "webpack-cli": "^2.0.15",
+    "webpack": "^4.20.2",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.3",
     "xhr": "2.5.0"
   },


### PR DESCRIPTION
'npm start' was broken by a webpack update. The solution is updating both:
    "webpack": "^4.20.2",
    "webpack-cli": "^3.1.1",

Signed-off-by: Yi Sun <syqust@gmail.com>